### PR TITLE
Clean up and move rules to a loop function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,19 @@
-const owlEye = console.log(
-  "\n",
-  "*********** Clean Code Rules ***********",
-  "\n",
-  "\n",
-  "1.Don't say I will back to fix it later",
-  "\n",
-  "2.Always leave the campground cleaner than you found it.",
-  "\n",
-  "3.The name of a variable, function or class, should answer all the big questions.",
-  "\n",
-  "4.Firstly, functions should be small, secondly functions should be smaller than that.",
-  "\n",
-  "5.Nothing can be quite so helpful as a well-placed comment.",
-  "\n",
-  "6.Code formatting is important. It is too important to ignore.",
-  "\n",
-  "7.Always make place for error handling.",
-  "\n",
-  "8.Set boundaries, and be careful when you use third party code.",
-  "\n",
-  "9.Don't ignore writing test, its the real shortcut.",
-  "\n",
-  "10.Classes should be small, with single responsibility principle",
-  "\n",
-  "11.Software Systems should separate the startuo process",
-  "\n"
-)
-module.exports = { owlEye }
+const principles = [
+  "Don't say I will back to fix it later,",
+  "Always leave the campground cleaner than you found it,",
+  "The name of a variable, function or class, should answer all the big questions,",
+  "Firstly, functions should be small, secondly functions should be smaller than that,",
+  "Nothing can be quite so helpful as a well-placed comment,",
+  "Code formatting is important. It is too important to ignore,",
+  "Always make place for error handling,",
+  "Set boundaries, and be careful when you use third party code,",
+  "Don't ignore writing test, its the real shortcut,",
+  "Classes should be small, with single responsibility principle,",
+  "Systems should separate the startup process.",
+].map((principle, index) => `${index + 1}. ${principle}`);
+
+console.info(
+  [, "*********** Clean Code Rules (OwlEye) ***********", , ...principles, ,].join("\n")
+);
+
+module.exports.owlEye = null;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "owl-eye",
   "version": "1.0.1",
-  "description": "This package is a reflection of clean code book and on and how to transform bad code into good code. Also its a number  of js design principles that help you to understand and  use the language effectively.",
+  "description": "This package is a reflection of clean code book and on and how to transform bad code into good code. Also it's a number of design principles that help you to understand and use the language effectively.",
   "main": "index.js",
   "scripts": {
     "test": "npm text"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "This package is a reflection of clean code book and on and how to transform bad code into good code. Also it's a number of design principles that help you to understand and use the language effectively.",
   "main": "index.js",
   "scripts": {
-    "test": "npm text"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey, Nice script - It might be useful to add a few env flags to check it's only used in dev. 

I noted that there's a lot of repetition in the console.log calls, most of these can be shifted out to a map where we auto-generate the index of the rule but also remove the repeated elements (following the DRY principle) such as the new line, the index position and format etc (using the template literal). 

Following along with other clean principles: 
- nullify the owlEye exported function - it's not clear why the return from console.log is returned (it's void anyway),
- removed the test script 'npm text' (as there are no tests or 'text' script),
- added "OwlEye" to the first log output - if this dependency is used in a large repo, finding where or what causes the log output might be tricky if unfamiliar with it,


Hope this is useful! 🙂 
Looking forward to seeing how this project evolves